### PR TITLE
#8 Add pagination to results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 # node modules
 requirements/node_modules/
 node_modules/
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [{
+            "name": "Python: Flask",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "env": {
+                "FLASK_APP": "app.py",
+                "FLASK_ENV": "development",
+                "FLASK_DEBUG": "0"
+            },
+            "args": ["run", "--no-debugger", "--no-reload"],
+            "jinja": true
+        },
+        {
+            "name": "Python: Flask",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "env": {
+                "FLASK_APP": "app.py",
+                "FLASK_ENV": "development",
+                "FLASK_DEBUG": "0"
+            },
+            "args": [
+                "run",
+                "--no-debugger",
+                "--no-reload"
+            ],
+            "jinja": true
+        }
+    ]
+}

--- a/app.py
+++ b/app.py
@@ -316,7 +316,8 @@ def puc_lookup():
         "pagesize": pagesize,
         "next": nexturl,
         "previous": prevurl,
-        "pagecount": pagecount
+        "pagecount": pagecount,
+        "currentpage": request.url
     }
     return json.jsonify(meta=meta_dict, data=result_list, paging=paging_dict)
 

--- a/app.py
+++ b/app.py
@@ -175,7 +175,6 @@ def sql_query(query_str, page=1, pagesize=app.config["PAGE_SIZE"], fetch_size="a
             return result, pagecount
     finally:
         sql.close()
-    
 
 
 @app.route("/pucs", methods=["GET"])
@@ -255,7 +254,7 @@ def puc_lookup():
         r"\s+",
         " ",
         """
-        SELECT 
+        SELECT
                %s,
                COUNT(DISTINCT dashboard_producttopuc.product_id) as num_prod
         FROM   dashboard_dsstoxlookup
@@ -317,7 +316,7 @@ def puc_lookup():
         "next": nexturl,
         "previous": prevurl,
         "pagecount": pagecount,
-        "currentpage": request.url
+        "currentpage": request.url,
     }
     return json.jsonify(meta=meta_dict, data=result_list, paging=paging_dict)
 

--- a/settings.py
+++ b/settings.py
@@ -47,7 +47,7 @@ class PyMySQLConfig(object):
             user=self.USER,
             password=self.PASSWORD,
             database=self.DATABASE,
-            client_flag = pymysql.constants.CLIENT.FOUND_ROWS
+            client_flag=pymysql.constants.CLIENT.FOUND_ROWS,
         )
 
 

--- a/settings.py
+++ b/settings.py
@@ -29,6 +29,7 @@ class FlaskConfig(object):
     SECRET_KEY = os.getenv("FLASK_SECRET_KEY")
     SERVER_NAME = os.getenv("FLASK_SERVER_NAME", None)
     APPLICATION_ROOT = os.getenv("FLASK_APPLICATION_ROOT", "/")
+    PAGE_SIZE = 100
 
 
 class PyMySQLConfig(object):

--- a/settings.py
+++ b/settings.py
@@ -29,7 +29,7 @@ class FlaskConfig(object):
     SECRET_KEY = os.getenv("FLASK_SECRET_KEY")
     SERVER_NAME = os.getenv("FLASK_SERVER_NAME", None)
     APPLICATION_ROOT = os.getenv("FLASK_APPLICATION_ROOT", "/")
-    PAGE_SIZE = 100
+    PAGE_SIZE = 10000
 
 
 class PyMySQLConfig(object):
@@ -47,6 +47,7 @@ class PyMySQLConfig(object):
             user=self.USER,
             password=self.PASSWORD,
             database=self.DATABASE,
+            client_flag = pymysql.constants.CLIENT.FOUND_ROWS
         )
 
 


### PR DESCRIPTION
Closes: #8 

This appends a LIMIT clause to the SQL query with offset and page size for pagination purposes, then uses the `SQL_CALC_FOUND_ROWS` function  to report the total number of rows that would have been returned without the LIMIT clause.

See: https://stackoverflow.com/questions/2400492/how-do-i-execute-sql-calc-found-rows-in-python-mysqldb