### PR TITLE
17 chemicals by puc

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -47,3 +47,14 @@ class ProductFilter(filters.FilterSet):
     class Meta:
         model = models.Product
         fields = []
+
+
+class ChemicalFilter(filters.FilterSet):
+    puc = filters.NumberFilter(
+        "extracted_text__data_document__product__puc__id",
+        help_text="A `puc_id` to filter chemicals against.",
+    )
+
+    class Meta:
+        model = models.RawChem
+        fields = []

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -30,7 +30,6 @@ class ChemicalSerializer(serializers.ModelSerializer):
     sid = serializers.SerializerMethodField(read_only=True, help_text="SID")
     name = serializers.SerializerMethodField(read_only=True, help_text="chemical name")
     cas = serializers.SerializerMethodField(read_only=True, help_text="CAS")
-    qa = serializers.SerializerMethodField(read_only=True)
     datadocument_id = serializers.IntegerField(
         source="extracted_text_id", read_only=True
     )
@@ -50,12 +49,9 @@ class ChemicalSerializer(serializers.ModelSerializer):
             return obj.raw_cas
         return obj.dsstox.true_cas
 
-    def get_qa(self, obj) -> bool:
-        return obj.dsstox is not None
-
     class Meta:
         model = models.RawChem
-        fields = ["id", "sid", "rid", "name", "cas", "qa", "datadocument_id"]
+        fields = ["id", "sid", "rid", "name", "cas", "datadocument_id"]
 
 
 class RIDChemicalSerializer(ChemicalSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -31,7 +31,9 @@ class ChemicalSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField(read_only=True, help_text="chemical name")
     cas = serializers.SerializerMethodField(read_only=True, help_text="CAS")
     datadocument_id = serializers.IntegerField(
-        source="extracted_text_id", read_only=True
+        source="extracted_text_id",
+        read_only=True,
+        help_text="the ID of the data document where this chemical was found",
     )
 
     def get_sid(self, obj) -> str:

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -31,6 +31,9 @@ class ChemicalSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField(read_only=True, help_text="chemical name")
     cas = serializers.SerializerMethodField(read_only=True, help_text="CAS")
     qa = serializers.SerializerMethodField(read_only=True)
+    datadocument_id = serializers.IntegerField(
+        source="extracted_text_id", read_only=True
+    )
 
     def get_sid(self, obj) -> str:
         if obj.dsstox is None:
@@ -52,7 +55,19 @@ class ChemicalSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.RawChem
-        fields = ["id", "sid", "rid", "name", "cas", "qa"]
+        fields = ["id", "sid", "rid", "name", "cas", "qa", "datadocument_id"]
+
+
+class RIDChemicalSerializer(ChemicalSerializer):
+    class Meta:
+        model = models.RawChem
+        fields = ["rid"]
+
+
+class RIDDocChemicalSerializer(ChemicalSerializer):
+    class Meta:
+        model = models.RawChem
+        fields = ["rid", "datadocument_id"]
 
 
 class DataTypeSerializer(serializers.ModelSerializer):

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -1,5 +1,5 @@
 from django.db.models import Prefetch
-from rest_framework import viewsets
+from rest_framework import generics, viewsets
 
 from app.api import filters, serializers
 from dashboard import models
@@ -30,3 +30,21 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
         ),
     )
     filterset_class = filters.ProductFilter
+
+
+class ChemicalViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = serializers.ChemicalSerializer
+    queryset = models.RawChem.objects.all().order_by("id")
+    filterset_class = filters.ChemicalFilter
+
+
+class RIDChemicalView(generics.ListAPIView):
+    serializer_class = serializers.RIDChemicalSerializer
+    queryset = models.RawChem.objects.all().order_by("id")
+    filterset_class = filters.ChemicalFilter
+
+
+class RIDDocChemicalView(generics.ListAPIView):
+    serializer_class = serializers.RIDDocChemicalSerializer
+    queryset = models.RawChem.objects.all().order_by("id")
+    filterset_class = filters.ChemicalFilter

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ from app.docs import views as docsviews
 router = routers.SimpleRouter()
 router.register(r"pucs", apiviews.PUCViewSet)
 router.register(r"products", apiviews.ProductViewSet)
+router.register(r"chemicals", apiviews.ChemicalViewSet)
 
 urlpatterns = [
     path(
@@ -16,6 +17,8 @@ urlpatterns = [
         docsviews.SchemaView.without_ui(cache_timeout=0),
         name="openapi-schema",
     ),
+    path("chemicals/rid/", apiviews.RIDChemicalView.as_view()),
+    path("chemicals/riddoc/", apiviews.RIDDocChemicalView.as_view()),
     path("", include(router.urls)),
     path("", docsviews.ReDocView.as_view()),
 ]


### PR DESCRIPTION
Closes #17

The API endpoints `/chemicals/rid/` and `chemicals/riddoc/` are required in the ticket, but are likely unnecessary.