### PR TITLE
29 upc endpoint

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -44,6 +44,10 @@ class ProductFilter(filters.FilterSet):
             ),
         )
 
+    upc = filters.CharFilter(
+        help_text="A Product UPC to filter products against.", initial="stub_47"
+    )
+
     class Meta:
         model = models.Product
         fields = []

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -138,6 +138,7 @@ class DocumentIdSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.DataDocument
+        fields = "__all__"
 
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -37,6 +37,7 @@ class TestPUC(TestCase):
 
 class TestProduct(TestCase):
     dtxsid = "DTXSID6026296"
+    upc = "stub_47"
 
     def test_retrieve(self):
         product = models.Product.objects.get(id=1867)
@@ -104,12 +105,17 @@ class TestProduct(TestCase):
         self.assertTrue("paging" in response)
         self.assertTrue("meta" in response)
         self.assertEqual(count, response["meta"]["count"])
-        # test with filter
+        # test with chemical filter
         count = models.Product.objects.filter(
             datadocument__extractedtext__rawchem__dsstox__sid=self.dtxsid
         ).count()
         response = self.get("/products/", {"chemical": self.dtxsid})
         self.assertEqual(count, response["meta"]["count"])
+        # test with UPC filter
+        count = models.Product.objects.filter(upc=self.upc).count()
+        response = self.get("/products/", {"upc": self.upc})
+        self.assertEqual(count, response["meta"]["count"])
+        self.assertEqual(self.upc, response["data"][0]["upc"])
 
 
 class TestChemical(TestCase):

--- a/manage.py
+++ b/manage.py
@@ -7,12 +7,12 @@ def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
+    except ImportError:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
     from django.core.management.commands.runserver import Command as runserver
 
     runserver.default_port = "8001"


### PR DESCRIPTION
pretty straight-forward here. I did edit the `manage.py` file so that if you try to run a command with it while not in the proper environment it will print the ImportError in your console which it was erring out on before. Other than that we just have another filed to filter on `{UPC}` to get products back.