### PR TITLE
1318 product api

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -134,26 +134,48 @@ class DocumentIdSerializer(serializers.ModelSerializer):
         model = models.DataDocument
         fields = "__all__"
 
+class PucIdSerializer(serializers.ModelSerializer):
+    def to_representation(self, instance):
+        return instance.id
+
+    class Meta:
+        model = models.PUC
+        fields = "__all__"
 
 class ProductSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField(
+        help_text="The unique numeric identifier for the product, \
+            used to cross-reference data obtained from other Factotum APIs.")
     name = serializers.CharField(
-        source="title", help_text="the name of this product", read_only=True
+        source="title", help_text="Name of the product.", read_only=True
     )
-    upc = serializers.CharField(help_text="UPC for this product", read_only=True)
-    documentIDs = DocumentIdSerializer(
-        source="documents",
-        many=True,
+    upc = serializers.CharField(help_text="The Universal Product Code, \
+        or unique numeric code used for scanning items at the point-of-sale. \
+            UPC may be represented as 'stub#' if the UPC for the product is \
+            not known.", read_only=True)
+    manufacturer = serializers.CharField(
+        help_text="Manufacturer of the product, if known.",
+    
+    )
+    brand = serializers.CharField(source="brand_name",
+    help_text = "Brand name for the product, if known. May be the same as the manufacturer."
+    )
+    puc_id = PucIdSerializer(
+        source="uber_puc", 
+        read_only=True, 
+        help_text=" Unique numeric identifier for the product use category assigned to the product \
+        (if one has been assigned). Use the PUCs API to obtain additional information on the PUC."
+        )
+    document_id = DocumentIdSerializer(
+        source="documents.first",
         read_only=True,
-        help_text="Data document IDs associated with this product",
-    )
-    puc = PUCSerializer(source="uber_puc", read_only=True, help_text="PUC")
-    chemicals = IngredientSerializer(
-        source="rawchems", many=True, read_only=True, help_text="chemicals"
+        help_text="Unique numeric identifier for the original data document associated with \
+            the product. Use the Documents API to obtain additional information on the document.",
     )
 
     class Meta:
         model = models.Product
-        fields = ["id", "name", "upc", "documentIDs", "puc", "chemicals"]
+        fields = ["id", "name", "upc", "manufacturer", "brand", "puc_id", "document_id"]
 
 
 class ChemicalSidAggSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -147,18 +147,29 @@ class ProductSerializer(serializers.ModelSerializer):
         help_text="The unique numeric identifier for the product, \
             used to cross-reference data obtained from other Factotum APIs.")
     name = serializers.CharField(
-        source="title", help_text="Name of the product.", read_only=True
+        source="title", 
+        help_text="Name of the product.", 
+        read_only=True, 
+        required=False, 
+        max_length=255
     )
     upc = serializers.CharField(help_text="The Universal Product Code, \
         or unique numeric code used for scanning items at the point-of-sale. \
             UPC may be represented as 'stub#' if the UPC for the product is \
-            not known.", read_only=True)
+            not known.", 
+            read_only=True, 
+            max_length=60
+            )
     manufacturer = serializers.CharField(
-        help_text="Manufacturer of the product, if known.",
-    
+        required=False, 
+        max_length=250,
+        help_text="Manufacturer of the product, if known."
     )
-    brand = serializers.CharField(source="brand_name",
-    help_text = "Brand name for the product, if known. May be the same as the manufacturer."
+    brand = serializers.CharField(
+        source="brand_name",
+        required=False, 
+        max_length=200,
+        help_text = "Brand name for the product, if known. May be the same as the manufacturer."
     )
     puc_id = PucIdSerializer(
         source="uber_puc", 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -134,6 +134,7 @@ class DocumentIdSerializer(serializers.ModelSerializer):
         model = models.DataDocument
         fields = "__all__"
 
+
 class PucIdSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         return instance.id
@@ -142,13 +143,14 @@ class PucIdSerializer(serializers.ModelSerializer):
         model = models.PUC
         fields = "__all__"
 
+
 class ProductSerializer(serializers.ModelSerializer):
     puc_id = PucIdSerializer(
-        source="uber_puc", 
-        read_only=True, 
+        source="uber_puc",
+        read_only=True,
         help_text=" Unique numeric identifier for the product use category assigned to the product \
-        (if one has been assigned). Use the PUCs API to obtain additional information on the PUC."
-        )
+        (if one has been assigned). Use the PUCs API to obtain additional information on the PUC.",
+    )
     document_id = DocumentIdSerializer(
         source="documents.first",
         read_only=True,
@@ -168,24 +170,20 @@ class ProductSerializer(serializers.ModelSerializer):
             "name": {
                 "help_text": "Name of the product.",
                 "label": "name",
-                "source": "title"
+                "source": "title",
             },
-            "upc":{
+            "upc": {
                 "help_text": "The Universal Product Code, \
         or unique numeric code used for scanning items at the point-of-sale. \
             UPC may be represented as 'stub#' if the UPC for the product is \
-            not known.",
+            not known."
             },
-            "manufacturer": {
-                "help_text": "Manufacturer of the product, if known.",
-            },
-            "brand":{
+            "manufacturer": {"help_text": "Manufacturer of the product, if known."},
+            "brand": {
                 "source": "brand_name",
                 "help_text": "Brand name for the product, if known. May be the same as the manufacturer.",
             },
         }
-            
-
 
 
 class ChemicalSidAggSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -126,34 +126,18 @@ class IngredientSerializer(ChemicalSerializer):
         ]
 
 
-class DocumentIdSerializer(serializers.ModelSerializer):
-    def to_representation(self, instance):
-        return instance.id
-
-    class Meta:
-        model = models.DataDocument
-        fields = "__all__"
-
-
-class PucIdSerializer(serializers.ModelSerializer):
-    def to_representation(self, instance):
-        return instance.id
-
-    class Meta:
-        model = models.PUC
-        fields = "__all__"
-
-
 class ProductSerializer(serializers.ModelSerializer):
-    puc_id = PucIdSerializer(
-        source="uber_puc",
+    puc_id = serializers.IntegerField(
+        source="uber_puc.id",
+        default=None,
         read_only=True,
+        allow_null=True,
         label="PUC ID",
         help_text=" Unique numeric identifier for the product use category assigned to the product \
         (if one has been assigned). Use the PUCs API to obtain additional information on the PUC.",
     )
-    document_id = DocumentIdSerializer(
-        source="documents.first",
+    document_id = serializers.IntegerField(
+        source="documents.first.id",
         read_only=True,
         label="Document ID",
         help_text="Unique numeric identifier for the original data document associated with \

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -143,34 +143,6 @@ class PucIdSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 class ProductSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField(
-        help_text="The unique numeric identifier for the product, \
-            used to cross-reference data obtained from other Factotum APIs.")
-    name = serializers.CharField(
-        source="title", 
-        help_text="Name of the product.", 
-        read_only=True, 
-        required=False, 
-        max_length=255
-    )
-    upc = serializers.CharField(help_text="The Universal Product Code, \
-        or unique numeric code used for scanning items at the point-of-sale. \
-            UPC may be represented as 'stub#' if the UPC for the product is \
-            not known.", 
-            read_only=True, 
-            max_length=60
-            )
-    manufacturer = serializers.CharField(
-        required=False, 
-        max_length=250,
-        help_text="Manufacturer of the product, if known."
-    )
-    brand = serializers.CharField(
-        source="brand_name",
-        required=False, 
-        max_length=200,
-        help_text = "Brand name for the product, if known. May be the same as the manufacturer."
-    )
     puc_id = PucIdSerializer(
         source="uber_puc", 
         read_only=True, 
@@ -187,6 +159,33 @@ class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Product
         fields = ["id", "name", "upc", "manufacturer", "brand", "puc_id", "document_id"]
+        extra_kwargs = {
+            "id": {
+                "help_text": "The unique numeric identifier for the product, \
+            used to cross-reference data obtained from other Factotum APIs.",
+                "label": "ID",
+            },
+            "name": {
+                "help_text": "Name of the product.",
+                "label": "name",
+                "source": "title"
+            },
+            "upc":{
+                "help_text": "The Universal Product Code, \
+        or unique numeric code used for scanning items at the point-of-sale. \
+            UPC may be represented as 'stub#' if the UPC for the product is \
+            not known.",
+            },
+            "manufacturer": {
+                "help_text": "Manufacturer of the product, if known.",
+            },
+            "brand":{
+                "source": "brand_name",
+                "help_text": "Brand name for the product, if known. May be the same as the manufacturer.",
+            },
+        }
+            
+
 
 
 class ChemicalSidAggSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -148,12 +148,14 @@ class ProductSerializer(serializers.ModelSerializer):
     puc_id = PucIdSerializer(
         source="uber_puc",
         read_only=True,
+        label="PUC ID",
         help_text=" Unique numeric identifier for the product use category assigned to the product \
         (if one has been assigned). Use the PUCs API to obtain additional information on the PUC.",
     )
     document_id = DocumentIdSerializer(
         source="documents.first",
         read_only=True,
+        label="Document ID",
         help_text="Unique numeric identifier for the original data document associated with \
             the product. Use the Documents API to obtain additional information on the document.",
     )
@@ -163,23 +165,28 @@ class ProductSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "upc", "manufacturer", "brand", "puc_id", "document_id"]
         extra_kwargs = {
             "id": {
+                "label": "Product ID",
                 "help_text": "The unique numeric identifier for the product, \
             used to cross-reference data obtained from other Factotum APIs.",
-                "label": "ID",
             },
             "name": {
+                "label": "Name",
                 "help_text": "Name of the product.",
-                "label": "name",
                 "source": "title",
             },
             "upc": {
+                "label": "UPC",
                 "help_text": "The Universal Product Code, \
         or unique numeric code used for scanning items at the point-of-sale. \
             UPC may be represented as 'stub#' if the UPC for the product is \
-            not known."
+            not known.",
             },
-            "manufacturer": {"help_text": "Manufacturer of the product, if known."},
+            "manufacturer": {
+                "label": "Manufacturer",
+                "help_text": "Manufacturer of the product, if known.",
+            },
             "brand": {
+                "label": "Brand",
                 "source": "brand_name",
                 "help_text": "Brand name for the product, if known. May be the same as the manufacturer.",
             },

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -37,66 +37,25 @@ class TestPUC(TestCase):
 
 class TestProduct(TestCase):
     dtxsid = "DTXSID6026296"
-    upc = "stub_47"
+    upc = "stub_1872"
 
     def test_retrieve(self):
         product = models.Product.objects.get(id=1867)
         response = self.get("/products/%d/" % product.id)
-        for key in ("id", "name", "upc", "documentIDs", "puc", "chemicals"):
+        for key in ("id", "name", "upc", "manufacturer", "brand", "puc_id", "document_id"):
             self.assertTrue(key in response)
         self.assertEqual(response["id"], product.id)
         self.assertEqual(response["name"], product.title)
         self.assertEqual(response["upc"], product.upc)
-        self.assertListEqual(response["documentIDs"], [130169, 147446])
-        self.assertEqual(response["puc"]["id"], product.uber_puc.id)
+        self.assertEqual(response["document_id"], 130169)
+        self.assertEqual(response["puc_id"], product.uber_puc.id)
         rawchems = [rc for rc in product.rawchems]
-        self.assertEqual(len(response["chemicals"]), len(rawchems))
-        chem_response = response["chemicals"][0]
-        chem = next(rc for rc in rawchems if rc.id == chem_response["id"])
-        if chem.dsstox is not None:
-            sid = chem.dsstox.sid
-            name = chem.dsstox.true_chemname
-            cas = chem.dsstox.true_cas
-        else:
-            sid = None
-            name = chem.raw_chem_name
-            cas = chem.raw_cas
-        try:
-            if (
-                chem.extractedchemical.lower_wf_analysis is None
-                and chem.extractedchemical.upper_wf_analysis is None
-            ):
-                min_weight_fraction = chem.extractedchemical.central_wf_analysis
-                max_weight_fraction = chem.extractedchemical.central_wf_analysis
-            else:
-                min_weight_fraction = chem.extractedchemical.lower_wf_analysis
-                max_weight_fraction = chem.extractedchemical.upper_wf_analysis
-        except models.ExtractedChemical.DoesNotExist:
-            min_weight_fraction = None
-            max_weight_fraction = None
 
-        data_type = chem.extracted_text.data_document.document_type
-        source = chem.extracted_text.data_document.data_group.data_source
-
-        self.assertEqual(chem_response["id"], chem.id)
-        self.assertEqual(chem_response["sid"], sid)
-        self.assertEqual(chem_response["rid"], chem.rid)
-        self.assertEqual(chem_response["name"], name)
-        self.assertEqual(chem_response["cas"], cas)
-        self.assertEqual(chem_response["min_weight_fraction"], min_weight_fraction)
-        self.assertEqual(chem_response["max_weight_fraction"], max_weight_fraction)
-        self.assertEqual(chem_response["data_type"]["name"], data_type.title)
-        self.assertEqual(
-            chem_response["data_type"]["description"], data_type.description
-        )
-        self.assertEqual(chem_response["source"]["name"], source.title)
-        self.assertEqual(chem_response["source"]["url"], source.url)
-        self.assertEqual(chem_response["source"]["description"], source.description)
 
     def test_page_size(self):
-        response = self.get("/products/?page_size=666")
+        response = self.get("/products/?page_size=35")
         self.assertTrue("paging" in response)
-        self.assertEqual(500, response["paging"]["size"])
+        self.assertEqual(35, response["paging"]["size"])
 
     def test_list(self):
         # test without filter

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -42,15 +42,21 @@ class TestProduct(TestCase):
     def test_retrieve(self):
         product = models.Product.objects.get(id=1867)
         response = self.get("/products/%d/" % product.id)
-        for key in ("id", "name", "upc", "manufacturer", "brand", "puc_id", "document_id"):
+        for key in (
+            "id",
+            "name",
+            "upc",
+            "manufacturer",
+            "brand",
+            "puc_id",
+            "document_id",
+        ):
             self.assertTrue(key in response)
         self.assertEqual(response["id"], product.id)
         self.assertEqual(response["name"], product.title)
         self.assertEqual(response["upc"], product.upc)
         self.assertEqual(response["document_id"], 130169)
         self.assertEqual(response["puc_id"], product.uber_puc.id)
-        rawchems = [rc for rc in product.rawchems]
-
 
     def test_page_size(self):
         response = self.get("/products/?page_size=35")

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -18,15 +18,12 @@ class PUCViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ProductViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    list: Service providing a list of all products in ChemExpoDB, along with metadata 
-    describing the product. In ChemExpoDB, a product is defined as an item having a 
-    unique UPC. Thus the same formulation (i.e., same chemical composition) may be 
-    associated with multiple products, each having their own UPC (e.g., different size 
-    bottles of a specific laundry detergent all have the same chemical make-up, but 
+    list: Service providing a list of all products in ChemExpoDB, along with metadata
+    describing the product. In ChemExpoDB, a product is defined as an item having a
+    unique UPC. Thus the same formulation (i.e., same chemical composition) may be
+    associated with multiple products, each having their own UPC (e.g., different size
+    bottles of a specific laundry detergent all have the same chemical make-up, but
     have different UPCs).
-    
-    Args:
-        viewsets ([type]): [description]
     """
 
     serializer_class = serializers.ProductSerializer

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -28,6 +28,7 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
     Args:
         viewsets ([type]): [description]
     """
+
     serializer_class = serializers.ProductSerializer
     queryset = models.Product.objects.prefetch_related(
         Prefetch("producttopuc_set"),

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -17,6 +17,17 @@ class PUCViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ProductViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    list: Service providing a list of all products in ChemExpoDB, along with metadata 
+    describing the product. In ChemExpoDB, a product is defined as an item having a 
+    unique UPC. Thus the same formulation (i.e., same chemical composition) may be 
+    associated with multiple products, each having their own UPC (e.g., different size 
+    bottles of a specific laundry detergent all have the same chemical make-up, but 
+    have different UPCs).
+    
+    Args:
+        viewsets ([type]): [description]
+    """
     serializer_class = serializers.ProductSerializer
     queryset = models.Product.objects.prefetch_related(
         Prefetch("producttopuc_set"),

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -42,7 +42,7 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
                 "extracted_text__data_document__data_group__data_source",
             ),
         ),
-    ).order_by("id")
+    )
     filterset_class = filters.ProductFilter
 
 

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -42,7 +42,7 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
                 "extracted_text__data_document__data_group__data_source",
             ),
         ),
-    )
+    ).order_by("id")
     filterset_class = filters.ProductFilter
 
 

--- a/app/core/generators.py
+++ b/app/core/generators.py
@@ -1,0 +1,28 @@
+from drf_yasg import generators, openapi, utils
+from drf_yasg.inspectors.field import get_basic_type_info
+import uritemplate
+
+
+class StandardSchemaGenerator(generators.OpenAPISchemaGenerator):
+    def get_path_parameters(self, path, view_cls):
+        # Get from serializer, not model
+        parameters = []
+        for variable in sorted(uritemplate.variables(path)):
+            if view_cls.serializer_class:
+                serializer = view_cls.serializer_class()
+                serializer_field = serializer.fields[variable]
+                attrs = get_basic_type_info(serializer_field) or {
+                    "type": openapi.TYPE_STRING
+                }
+                description = getattr(serializer_field, "help_text")
+                title = getattr(serializer_field, "label")
+                field = openapi.Parameter(
+                    name=variable,
+                    title=utils.force_real_str(title),
+                    description=utils.force_real_str(description),
+                    required=True,
+                    in_=openapi.IN_PATH,
+                    **attrs,
+                )
+                parameters.append(field)
+        return parameters

--- a/app/core/inspectors.py
+++ b/app/core/inspectors.py
@@ -172,14 +172,6 @@ class StandardPaginatorInspector(inspectors.DjangoRestResponsePagination):
         ]
 
 
-class NoSchemaTitleInspector(inspectors.FieldInspector):
-    def process_result(self, result, method_name, obj, **kwargs):
-        if isinstance(result, openapi.Schema.OR_REF):
-            schema = openapi.resolve_ref(result, self.components)
-            schema.pop("title", None)
-        return result
-
-
 class StandardAutoSchema(inspectors.SwaggerAutoSchema):
     def get_operation(self, operation_keys=None):
         operation = super().get_operation(operation_keys)

--- a/config/settings.py
+++ b/config/settings.py
@@ -80,7 +80,6 @@ REST_FRAMEWORK = {
 SWAGGER_SETTINGS = {
     "DEFAULT_AUTO_SCHEMA_CLASS": "app.core.inspectors.StandardAutoSchema",
     "DEFAULT_FIELD_INSPECTORS": [
-        "app.core.inspectors.NoSchemaTitleInspector",
         "drf_yasg.inspectors.CamelCaseJSONFilter",
         "drf_yasg.inspectors.ReferencingSerializerInspector",
         "drf_yasg.inspectors.RelatedFieldInspector",

--- a/config/settings.py
+++ b/config/settings.py
@@ -78,6 +78,7 @@ REST_FRAMEWORK = {
 }
 
 SWAGGER_SETTINGS = {
+    "DEFAULT_GENERATOR_CLASS": "app.core.generators.StandardSchemaGenerator",
     "DEFAULT_AUTO_SCHEMA_CLASS": "app.core.inspectors.StandardAutoSchema",
     "DEFAULT_FIELD_INSPECTORS": [
         "drf_yasg.inspectors.CamelCaseJSONFilter",


### PR DESCRIPTION
Closes: https://github.com/HumanExposure/factotum/issues/1318

This flattens out the `/product/` endpoint, removing the arrays of document IDs and chemicals that had been previously returned. 

Review should cover the documentation at `http://127.0.0.1:8001/#operation/productsList` and `http://127.0.0.1:8001/#operation/productsRead`.