### PR TITLE
1319 Documents api

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -206,14 +206,14 @@ class DocumentSerializer(serializers.ModelSerializer):
              See the Products API for additional information on the product.",
         )
 
-    chemicals = ExtractedChemicalSerializer(
-        source="extractedtext.rawchem.select_subclasses()",
-        many=True,
-        read_only=True,
-        label="chemicals",
-        help_text="TBD",
-    )
+    chemicals = serializers.SerializerMethodField()
 
+    def get_chemicals(self, obj):
+        return ExtractedChemicalSerializer(
+                    obj.extractedtext.rawchem.select_subclasses("extractedchemical"),
+                    many=True
+                ).data
+    
     class Meta:
         model = models.DataDocument
         fields = [

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -190,13 +190,21 @@ class DocumentSerializer(serializers.ModelSerializer):
         help_text="Publication date for the document.",
     )
 
-    type = serializers.CharField(
+    data_type = serializers.CharField(
         source="data_group.group_type.title",
         read_only=True,
         allow_null=False,
-        label="Document type",
+        label="Data type",
         help_text="Type of data provided by the document, e.g. 'Composition' \
             indicates the document provides data on chemical composition of a consumer product.",
+    )
+    document_type = serializers.CharField(
+        source="document_type.title",
+        read_only=True,
+        allow_null=False,
+        label="Document type",
+        help_text="Standardized description of the type of document (e.g. Safety Data Sheet (SDS), \
+            product label, journal article, government report).",
     )
     url = serializers.URLField(
         source="pdf_url",
@@ -226,7 +234,8 @@ class DocumentSerializer(serializers.ModelSerializer):
             "subtitle",
             "organization",
             "date",
-            "type",
+            "data_type",
+            "document_type",
             "url",
             "notes",
             "products",

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -106,6 +106,13 @@ class ExtractedChemicalSerializer(RawChemSerializer):
             "upper_wf_analysis",
             "ingredient_rank",
         ]
+        extra_kwargs = {
+            "lower_wf_analysis": {
+                "label": "Weight fraction - lower",
+                "help_text": "Unfortunately this does not appear in the \
+                    automatic documentation",
+            }
+        }
 
 
 class DataTypeSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -198,7 +198,6 @@ class DocumentSerializer(serializers.ModelSerializer):
         help_text="Type of data provided by the document, e.g. 'Composition' \
             indicates the document provides data on chemical composition of a consumer product.",
     )
-
     url = serializers.URLField(
         source="pdf_url",
         read_only=True,
@@ -209,7 +208,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     products = serializers.PrimaryKeyRelatedField(
         many=True,
         read_only=True,
-        label="ProductIDs",
+        label="Product IDs",
         help_text="Unique numeric identifiers for products associated with the \
              original data document. May be >1 product associated with each document. \
              See the Products API for additional information on the product.",

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -227,6 +227,63 @@ class ProductSerializer(serializers.ModelSerializer):
         }
 
 
+class ExtractedChemicalSerializer(serializers.ModelSerializer):
+
+    chemical_id = serializers.CharField(
+        label="DTXSID",
+        help_text="The DSSTox Substance Identifier for each chemical included on the document. \
+            May be >1 per document. See the chemicals API for additional information on the \
+            chemical substance.",
+        source="dsstox.sid",
+    )
+
+    class Meta:
+        model = models.ExtractedChemical
+        fields = [
+            "chemical_id",
+            "component",
+            "lower_weight_fraction",
+            "central_weight_fraction",
+            "upper_weight_fraction",
+            "ingredient_rank",
+        ]
+        extra_kwargs = {
+            "component": {
+                "label": "Component",
+                "help_text": "Subcategory grouping chemical information on the document (may \
+                    or may not be populated). Used when the document provides information on \
+                    chemical make-up of multiple components or portions of a product (e.g. a \
+                    hair care set (product) which contains a bottle of shampoo (component 1) \
+                    and bottle of body wash (component 2)).",
+            },
+            "lower_weight_fraction": {
+                "label": "Weight fraction - lower",
+                "help_text": "Lower bound of weight fraction for the chemical substance in the \
+                    product, if provided on the document. If weight fraction is provided as a range, \
+                    lower and upper values are populated. Values range from 0-1.",
+                "source": "lower_wf_analysis",
+            },
+            "central_weight_fraction": {
+                "label": "Weight fraction - central",
+                "help_text": "Central value for weight fraction for the chemical substance in the \
+                    product, if provided on the document. If weight fraction is provided as a point \
+                    estimate, the central value is populated. Values range from 0-1.",
+                "source": "central_wf_analysis",
+            },
+            "upper_weight_fraction": {
+                "label": "Weight fraction - upper",
+                "help_text": "Upper bound of weight fraction for the chemical substance in the product,\
+                 if provided on the document. If weight fraction is provided as a range, lower and \
+                 upper values are populated. Values range from 0-1.",
+                "source": "lower_wf_analysis",
+            },
+            "ingredient_rank": {
+                "label": "Ingredient rank",
+                "help_text": "Rank of the chemical in the ingredient list or document.",
+            },
+        }
+
+
 class DocumentSerializer(serializers.ModelSerializer):
     date = serializers.SerializerMethodField(
         default=None,
@@ -267,44 +324,9 @@ class DocumentSerializer(serializers.ModelSerializer):
              See the Products API for additional information on the product.",
     )
 
-    chemicals = serializers.SerializerMethodField(
-        help_text="""A collection of extracted chemicals related to the document. \
-        The chemical attributes include:<br>
-        *Component `component`:* Subcategory grouping chemical information on the document (may or \
-            may not be populated). Used when the document provides information on chemical \
-                make-up of multiple components or portions of a product (e.g. a hair care \
-                    set (product) which contains a bottle of shampoo (component 1) and \
-                        bottle of body wash (component 2))<br>
-        *DTXSID `sid`:* The DSSTox Substance Identifier for each chemical included on the document. \
-            May be >1 per document. See the chemicals API for additional information on the \
-                chemical substance.<br>
-        *Weight fraction - lower `lower_wf_analysis`:* Lower bound of weight fraction for the chemical substance \
-            in the product, if provided on the document. If weight fraction is provided as a \
-            range, lower and upper values are populated. Values range from 0-1.<br>
-        *Weight fraction - central `central_wf_analysis`:* Central value for weight fraction for the chemical substance \
-            in the product, if provided on the document. If weight fraction is provided as a \
-            point estimate, the central value is populated. Values range from 0-1.<br>
-        *Weight fraction - upper `upper_wf_analysis`:* Upper bound of weight fraction for the chemical substance \
-            in the product, if provided on the document. If weight fraction is provided as a range, \
-                lower and upper values are populated. Values range from 0-1.<br>
-        *Ingredient rank `ingredient_rank`:* Rank of the chemical in the ingredient list or document.
-            """,
-        label="Chemicals",
-        read_only=True,
+    chemicals = ExtractedChemicalSerializer(
+        label="Chemicals", many=True, read_only=True
     )
-
-    def get_chemicals(self, obj):
-        if obj.is_extracted:
-            return ExtractedChemicalSerializer(
-                obj.extractedtext.rawchem.select_subclasses(
-                    "extractedchemical"
-                ).order_by(
-                    "component"
-                ),  # not possible to sort by ingredient_rank, since the subclass is undetermined
-                many=True,
-            ).data
-        else:
-            return None
 
     class Meta:
         model = models.DataDocument

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-
 from dashboard import models
 
 
@@ -26,7 +25,8 @@ class PUCSerializer(serializers.ModelSerializer):
         ]
 
 
-class ChemicalSerializer(serializers.ModelSerializer):
+class RawChemSerializer(serializers.ModelSerializer):
+    
     sid = serializers.SerializerMethodField(read_only=True, help_text="SID")
     name = serializers.SerializerMethodField(
         read_only=True,
@@ -36,12 +36,14 @@ class ChemicalSerializer(serializers.ModelSerializer):
         read_only=True,
         help_text="The true CAS for curated records, the raw CAS otherwise",
     )
-    datadocument_id = serializers.IntegerField(
-        source="extracted_text_id",
+    component = serializers.CharField(
         read_only=True,
-        help_text="the ID of the data document where this chemical was found",
+        help_text="Subcategory grouping chemical information on the document \
+                    (may or may not be populated). Used when the document provides \
+                    information on chemical make-up of multiple components or portions \
+                    of a product (e.g. a hair care set (product) which contains a bottle of \
+                    shampoo (component 1) and bottle of body wash (component 2))",
     )
-
     def get_sid(self, obj) -> str:
         if obj.dsstox is None:
             return None
@@ -56,41 +58,19 @@ class ChemicalSerializer(serializers.ModelSerializer):
         if obj.dsstox is None:
             return obj.raw_cas
         return obj.dsstox.true_cas
-
     class Meta:
         model = models.RawChem
-        fields = ["id", "sid", "rid", "name", "cas", "datadocument_id"]
+        fields = ["id", "sid", "rid", "name", "cas", "component"]
+    
 
-
-class DataTypeSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source="title")
-
-    class Meta:
-        model = models.DocumentType
-        fields = ["name", "description"]
-
-
-class DataSourceSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source="title")
-
-    class Meta:
-        model = models.DataSource
-        fields = ["name", "url", "description"]
-
-
-class IngredientSerializer(ChemicalSerializer):
+class ExtractedChemicalSerializer(RawChemSerializer):
+    """Inherits from RawChemSerializer
+    """
     min_weight_fraction = serializers.SerializerMethodField(
         read_only=True, help_text="minimum weight fraction"
     )
     max_weight_fraction = serializers.SerializerMethodField(
         read_only=True, help_text="maximum weight fraction"
-    )
-    data_type = DataTypeSerializer(
-        source="extracted_text.data_document.document_type", help_text="data type"
-    )
-    source = DataSourceSerializer(
-        source="extracted_text.data_document.data_group.data_source",
-        help_text="data source",
     )
 
     def get_min_weight_fraction(self, obj) -> float:
@@ -112,18 +92,33 @@ class IngredientSerializer(ChemicalSerializer):
             return None
 
     class Meta:
-        model = models.RawChem
-        fields = [
-            "id",
-            "sid",
-            "rid",
-            "name",
-            "cas",
-            "min_weight_fraction",
-            "max_weight_fraction",
-            "data_type",
-            "source",
-        ]
+            model = models.RawChem
+            fields = [
+                "id",
+                "sid",
+                "rid",
+                "name",
+                "cas",
+                "min_weight_fraction",
+                "max_weight_fraction",
+                "component"
+            ]
+
+
+class DataTypeSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="title")
+
+    class Meta:
+        model = models.DocumentType
+        fields = ["name", "description"]
+
+
+class DataSourceSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="title")
+
+    class Meta:
+        model = models.DataSource
+        fields = ["name", "url", "description"]
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -173,6 +168,86 @@ class ProductSerializer(serializers.ModelSerializer):
                 "label": "Brand",
                 "source": "brand_name",
                 "help_text": "Brand name for the product, if known. May be the same as the manufacturer.",
+            },
+        }
+
+
+class DocumentSerializer(serializers.ModelSerializer):
+    date = serializers.ReadOnlyField(
+        source="extractedtext__doc_date",
+        default=None,
+        read_only=True,
+        allow_null=True,
+        label="Date",
+        help_text="Publication date for the document.",
+    )
+    type = serializers.CharField(
+        source="data_group__group_type__title",
+        read_only=True,
+        allow_null=False,
+        label="Document type",
+        help_text="Type of data provided by the document, e.g. 'Composition' \
+            indicates the document provides data on chemical composition of a consumer product.",
+    )
+
+    url = serializers.URLField(
+        source="pdf_url",
+        read_only=True,
+        allow_null=True,
+        label="URL",
+        help_text="Link to a locally stored copy of the document.",
+    )
+    products = serializers.PrimaryKeyRelatedField(
+        many=True, 
+        read_only=True,
+        label="ProductIDs",
+        help_text="Unique numeric identifiers for products associated with the \
+             original data document. May be >1 product associated with each document. \
+             See the Products API for additional information on the product.",
+        )
+
+    chemicals = ExtractedChemicalSerializer(
+        source="extractedtext.rawchem.select_subclasses()",
+        many=True,
+        read_only=True,
+        label="chemicals",
+        help_text="TBD",
+    )
+
+    class Meta:
+        model = models.DataDocument
+        fields = [
+            "id",
+            "title",
+            "subtitle",
+            "organization",
+            "date",
+            "type",
+            "url",
+            "notes",
+            "products",
+            "chemicals",
+        ]
+        extra_kwargs = {
+            "id": {
+                "label": "Document ID",
+                "help_text": "The unique numeric identifier for the original data document providing data to ChemExpoDB.",
+            },
+            "title": {"label": "Title", "help_text": "Title of the document."},
+            "subtitle": {
+                "label": "Subtitle",
+                "help_text": "Subtitle for the document. \
+                May also be the heading/caption for the table from which data was extracted.",
+            },
+            "organization": {
+                "label": "Organization",
+                "help_text": "The organization which published the document. If the document is \
+                    a peer-reviewed journal article, the name of the journal.",
+            },
+            "notes": {
+                "label": "Notes",
+                "source": "note",
+                "help_text": "General notes about the data document, written by ChemExpoDB data curators.",
             },
         }
 

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -137,6 +137,6 @@ class TestDocuments(TestCase):
         chem_orm = chems[2]
         chem_json = response.get("chemicals")[2]
         self.assertEqual(
-            float(chem_json.get("central_wf_analysis")),
+            float(chem_json.get("central_weight_fraction")),
             float(chem_orm.central_wf_analysis),
         )

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -147,3 +147,27 @@ class TestChemical(TestCase):
         self.assertRaises(
             AttributeError, lambda: self.get("/chemicals/distinct/fake_attribute/")
         )
+
+
+class TestDocuments(TestCase):
+    def test_retrieve_by_id(self):
+        chem_count = models.RawChem.objects.filter(extracted_text_id=id).count()
+        docid = 156051
+        response = self.get(f"/documents/{docid}/")
+        dd = models.DataDocument.objects.get(pk=docid)
+
+        # Check the method-derived values
+        self.assertEqual(response.get("date"), dd.extractedtext.doc_date)
+        self.assertEqual(response.get("type"), dd.data_group.group_type.title)
+        # the json products should match the ORM products
+        prods = dd.products.values_list("id", flat=True)
+        self.assertEqual(response.get("products"), list(prods))
+
+        # the json chemicals should match the ORM chemicals
+        chems = dd.extractedtext.rawchem.select_subclasses()
+        chem_orm = chems[2]
+        chem_json = response.get("chemicals")[2]
+        self.assertEqual(
+            float(chem_json.get("central_wf_analysis")),
+            float(chem_orm.central_wf_analysis),
+        )

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -125,7 +125,7 @@ class TestChemical(TestCase):
 
     def test_distinct_queries(self):
         response = self.get("/chemicals/distinct/sid/")
-        self.assertEqual(response["data"][0]["sid"], "DTXSID1020273")
+        self.assertEqual(response["data"][0]["sid"], "DTXSID00184990")
         self.assertTrue("paging" in response)
         self.assertTrue("meta" in response)
 
@@ -135,13 +135,13 @@ class TestChemical(TestCase):
         self.assertTrue("meta" in response)
 
         response = self.get("/chemicals/distinct/true_chemname/")
-        self.assertEqual(response["data"][0]["true_chemname"], "bisphenol a")
+        self.assertEqual(response["data"][0]["true_chemname"], "benzene")
         self.assertTrue("paging" in response)
         self.assertTrue("meta" in response)
 
         # Test case insensitivity
         response = self.get("/chemicals/distinct/TrUe_ChEmNaMe/")
-        self.assertEqual(response["data"][0]["true_chemname"], "bisphenol a")
+        self.assertEqual(response["data"][0]["true_chemname"], "benzene")
 
         # Test non-included path
         self.assertRaises(

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -127,7 +127,7 @@ class TestDocuments(TestCase):
 
         # Check the method-derived values
         self.assertEqual(response.get("date"), dd.extractedtext.doc_date)
-        self.assertEqual(response.get("type"), dd.data_group.group_type.title)
+        self.assertEqual(response.get("data_type"), dd.data_group.group_type.title)
         # the json products should match the ORM products
         prods = dd.products.values_list("id", flat=True)
         self.assertEqual(response.get("products"), list(prods))

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -161,7 +161,6 @@ class TestChemical(TestCase):
 
 class TestDocuments(TestCase):
     def test_retrieve_by_id(self):
-        chem_count = models.RawChem.objects.filter(extracted_text_id=id).count()
         docid = 156051
         response = self.get(f"/documents/{docid}/")
         dd = models.DataDocument.objects.get(pk=docid)

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -155,6 +155,7 @@ class TestDocuments(TestCase):
         # Check the method-derived values
         self.assertEqual(response.get("date"), dd.extractedtext.doc_date)
         self.assertEqual(response.get("data_type"), dd.data_group.group_type.title)
+        self.assertEqual(response.get("document_type"), dd.document_type.title)
         # the json products should match the ORM products
         prods = dd.products.values_list("id", flat=True)
         self.assertEqual(response.get("products"), list(prods))

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -42,6 +42,21 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
     )
     filterset_class = filters.ProductFilter
 
+class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    list: Service providing a list of all documents in ChemExpoDB, along with 
+    metadata describing the document. Service also provides the actual data 
+    points found in, and extracted from, the document. e.g., chemicals and their 
+    weight fractions may be included for composition documents.
+    """
+
+    serializer_class = serializers.DocumentSerializer
+    queryset = models.DataDocument.objects.prefetch_related(
+        Prefetch("extractedtext"),
+        Prefetch("products")
+        ).all().order_by("-id")
+    
+
 
 class ChemicalViewSet(viewsets.ReadOnlyModelViewSet):
     """
@@ -62,7 +77,7 @@ class ChemicalViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     lookup_field = "rid"
-    serializer_class = serializers.ChemicalSerializer
+    serializer_class = serializers.RawChemSerializer
     queryset = models.RawChem.objects.all().order_by("id")
     filterset_class = filters.ChemicalFilter
 

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -46,6 +46,7 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
     )
     filterset_class = filters.ProductFilter
 
+
 class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
     list: Service providing a list of all documents in ChemExpoDB, along with 
@@ -55,11 +56,13 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     serializer_class = serializers.DocumentSerializer
-    queryset = models.DataDocument.objects.prefetch_related(
-        Prefetch("extractedtext"),
-        Prefetch("products")
-        ).all().order_by("-id")
-    
+    queryset = (
+        models.DataDocument.objects.prefetch_related(
+            Prefetch("extractedtext"), Prefetch("products")
+        )
+        .all()
+        .order_by("-id")
+    )
 
 
 class ChemicalViewSet(viewsets.ReadOnlyModelViewSet):

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -61,7 +61,7 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
             Prefetch("products"),
         )
         .straight_join()
-        .select_related("data_group__group_type")
+        .select_related("data_group__group_type", "document_type")
         .order_by("-id")
     )
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,7 +14,7 @@ DJANGO_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.staticfiles",
 ]
-THIRD_PARTY_APPS = ["dashboard", "django_filters", "rest_framework"]
+THIRD_PARTY_APPS = ["dashboard", "django_filters", "rest_framework", "django_mysql"]
 LOCAL_APPS = ["app.api", "app.docs", "app.core"]
 INSTALLED_APPS = THIRD_PARTY_OVERRIDE_APPS + DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
@@ -53,6 +53,14 @@ DATABASES = {
         "TEST": {"NAME": "test_" + env.SQL_DATABASE + "_factotum_ws"},
     }
 }
+
+DJANGO_MYSQL_REWRITE_QUERIES = True
+SILENCED_SYSTEM_CHECKS = [
+    "django_mysql.W001",
+    "django_mysql.W002",
+    "django_mysql.W003",
+    "django_mysql.W004",
+]
 
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "America/New_York"

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ from app.docs import views as docsviews
 router = routers.SimpleRouter()
 router.register(r"pucs", apiviews.PUCViewSet)
 router.register(r"products", apiviews.ProductViewSet)
+router.register(r"documents", apiviews.DocumentViewSet)
 router.register(r"chemicals", apiviews.ChemicalViewSet)
 
 urlpatterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black==19.3b0
 Django>=2.2,<2.3
 django-filter>=2.2.0,<2.3
+django-mysql>=3.3.0,<3.4
 djangorestframework>=3.10.3,<3.11
 drf-yasg>=1.17.0,<1.18.0
 gunicorn>=20.0.0,<20.1.0


### PR DESCRIPTION
closes: https://github.com/HumanExposure/factotum/issues/1319
dependent on: https://github.com/HumanExposure/factotum/pull/1369

The issue is on the `factotum` board, but the changes are to the `factotum_ws` repo.

I concluded that the serializers in Django REST Framework cannot directly access the chemicals for a document through the `source` attribute because of the model inheritance. That meant that while there could be `ModelSerializer` fields for individual `RawChem` and `ExtractedChemical` records, I had to use a `SerializerMethodField` for the `chemicals` list in each document, and DRF cannot auto-generate the documentation for the sub-fields inside `chemicals`. Maybe there is a better way that we will discover.