### PR TITLE
1391 wf data incorrect

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -170,7 +170,7 @@ class ExtractedChemicalSerializer(serializers.ModelSerializer):
                 "help_text": "Upper bound of weight fraction for the chemical substance in the product,\
                  if provided on the document. If weight fraction is provided as a range, lower and \
                  upper values are populated. Values range from 0-1.",
-                "source": "lower_wf_analysis",
+                "source": "upper_wf_analysis",
             },
             "ingredient_rank": {
                 "label": "Ingredient rank",

--- a/app/api/tests.py
+++ b/app/api/tests.py
@@ -1,7 +1,10 @@
+import uuid
+
 from django.db import connection, reset_queries
 from django.test.utils import override_settings
 from drf_yasg.generators import EndpointEnumerator
 
+from app.api.serializers import ExtractedChemicalSerializer
 from app.core.test import TestCase
 
 from dashboard import models
@@ -179,6 +182,10 @@ class TestDocument(TestCase):
         self.assertEqual(doc.document_type.title, response["document_type"])
         self.assertEqual(doc.file.url, response["url"])
         self.assertEqual(doc.note, response["notes"])
+        self.assertEqual(
+            doc.chemicals.filter(dsstox__isnull=False).count(),
+            len(response["chemicals"]),
+        )
 
     def test_list(self):
         # test without filter
@@ -187,3 +194,44 @@ class TestDocument(TestCase):
         self.assertTrue("meta" in response)
         count = models.DataDocument.objects.count()
         self.assertEqual(count, response["meta"]["count"])
+
+
+class TestExtractedChemicalSerializer(TestCase):
+    def test_serialize(self):
+        et = models.ExtractedText.objects.first()
+        dsstox = models.DSSToxLookup.objects.first()
+        extracted_chemical = models.ExtractedChemical.objects.create(
+            extracted_text=et,
+            dsstox=dsstox,
+            component=str(uuid.uuid1()),
+            lower_wf_analysis=0.1,
+            central_wf_analysis=0.2,
+            upper_wf_analysis=0.3,
+            ingredient_rank=1,
+        )
+        serialized_extracted_chemical = ExtractedChemicalSerializer(extracted_chemical)
+
+        self.assertEqual(
+            extracted_chemical.dsstox.sid,
+            serialized_extracted_chemical.data["chemical_id"],
+        )
+        self.assertEqual(
+            extracted_chemical.component,
+            serialized_extracted_chemical.data["component"],
+        )
+        self.assertEqual(
+            format(extracted_chemical.lower_wf_analysis, ".15f"),
+            serialized_extracted_chemical.data["lower_weight_fraction"],
+        )
+        self.assertEqual(
+            format(extracted_chemical.central_wf_analysis, ".15f"),
+            serialized_extracted_chemical.data["central_weight_fraction"],
+        )
+        self.assertEqual(
+            format(extracted_chemical.upper_wf_analysis, ".15f"),
+            serialized_extracted_chemical.data["upper_weight_fraction"],
+        )
+        self.assertEqual(
+            extracted_chemical.ingredient_rank,
+            serialized_extracted_chemical.data["ingredient_rank"],
+        )


### PR DESCRIPTION
closes #1391

Simple fix.  ExtractedChemicalSerializer.upper_weight_fraction was sourcing the wrong field.

- Added a small test to document endpoint to verify the correct number of chemicals were being attached.
- Added a test for extracted chemical serializer.  There is no endpoint for this one so I figured it should be tested in isolation.  Test will pass even if additional fields are added later to fit with the rest of our endpoint tests.